### PR TITLE
SFAT-241 - backups / SFAT-237 - encryption / NFT

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -35,4 +35,5 @@ module "deploy" {
   deletion_protection             = false
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
+  backup_retention_period         = 35
 }

--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -36,5 +36,5 @@ module "deploy" {
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
   backup_retention_period         = 35
-  guided_match_cluster_instances  = 3
+  guided_match_cluster_instances  = length(local.availability_zones)
 }

--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -36,4 +36,5 @@ module "deploy" {
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
   backup_retention_period         = 35
+  guided_match_cluster_instances  = 3
 }

--- a/terraform/environments/sbx1/main.tf
+++ b/terraform/environments/sbx1/main.tf
@@ -35,4 +35,5 @@ module "deploy" {
   deletion_protection             = false
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
+  guided_match_cluster_instances  = 2
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -34,4 +34,5 @@ module "guided-match" {
   skip_final_snapshot             = var.skip_final_snapshot
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   backup_retention_period         = var.backup_retention_period
+  cluster_instances               = var.guided_match_cluster_instances
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -33,4 +33,5 @@ module "guided-match" {
   deletion_protection             = var.deletion_protection
   skip_final_snapshot             = var.skip_final_snapshot
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
+  backup_retention_period         = var.backup_retention_period
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -22,3 +22,8 @@ variable "skip_final_snapshot" {
 variable "enabled_cloudwatch_logs_exports" {
   type = list(string)
 }
+
+variable "backup_retention_period" {
+  type    = number
+  default = 1
+}

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -24,6 +24,11 @@ variable "enabled_cloudwatch_logs_exports" {
 }
 
 variable "backup_retention_period" {
+type    = number
+  default = 1
+}
+
+variable "guided_match_cluster_instances" {
   type    = number
   default = 1
 }

--- a/terraform/modules/guided-match/main.tf
+++ b/terraform/modules/guided-match/main.tf
@@ -50,6 +50,17 @@ data "aws_ssm_parameter" "master_password" {
   with_decryption = true
 }
 
+resource "aws_kms_key" "guided_match" {
+  description = "Key for Guided Match Postgres Aurora Cluster - ccs-eu2-${lower(var.environment)}-db-guided-match"
+
+  tags = {
+    Project     = module.globals.project_name
+    Environment = upper(var.environment)
+    Cost_Code   = module.globals.project_cost_code
+    AppType     = "ECS"
+  }
+}
+
 resource "aws_rds_cluster" "default" {
   cluster_identifier              = "ccs-eu2-${lower(var.environment)}-db-guided-match"
   availability_zones              = var.availability_zones
@@ -63,9 +74,11 @@ resource "aws_rds_cluster" "default" {
   db_subnet_group_name            = aws_db_subnet_group.guided_match.name
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   skip_final_snapshot             = var.skip_final_snapshot
-  final_snapshot_identifier       = "final-snaphot-agreements-${uuid()}"
+  final_snapshot_identifier       = "final-snaphot-guided-match-${uuid()}"
   backup_retention_period         = var.backup_retention_period
   preferred_backup_window         = "00:24-00:54"
+  kms_key_id                      = aws_kms_key.guided_match.arn
+  storage_encrypted               = true
 
   lifecycle {
     ignore_changes = [
@@ -75,7 +88,7 @@ resource "aws_rds_cluster" "default" {
 }
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
-  count                = 1
+  count                = var.cluster_instances
   identifier           = "ccs-eu2-${lower(var.environment)}-db-guided-match-${count.index}"
   cluster_identifier   = aws_rds_cluster.default.id
   instance_class       = "db.t3.medium"
@@ -88,6 +101,6 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 resource "aws_ssm_parameter" "instance_endpoint" {
   name      = "${lower(var.environment)}-guided-match-db-endpoint"
   type      = "String"
-  value     = aws_rds_cluster_instance.cluster_instances[0].endpoint
+  value     = aws_rds_cluster.default.endpoint
   overwrite = true
 }

--- a/terraform/modules/guided-match/main.tf
+++ b/terraform/modules/guided-match/main.tf
@@ -64,6 +64,8 @@ resource "aws_rds_cluster" "default" {
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   skip_final_snapshot             = var.skip_final_snapshot
   final_snapshot_identifier       = "final-snaphot-agreements-${uuid()}"
+  backup_retention_period         = var.backup_retention_period
+  preferred_backup_window         = "00:24-00:54"
 
   lifecycle {
     ignore_changes = [

--- a/terraform/modules/guided-match/variables.tf
+++ b/terraform/modules/guided-match/variables.tf
@@ -26,3 +26,7 @@ variable "skip_final_snapshot" {
 variable "enabled_cloudwatch_logs_exports" {
   type = list(string)
 }
+
+variable "backup_retention_period" {
+  type    = number
+}

--- a/terraform/modules/guided-match/variables.tf
+++ b/terraform/modules/guided-match/variables.tf
@@ -30,3 +30,7 @@ variable "enabled_cloudwatch_logs_exports" {
 variable "backup_retention_period" {
   type    = number
 }
+
+variable "cluster_instances" {
+  type = number
+}


### PR DESCRIPTION
SFAT-241 - Backup window & retention period settings based on email (in JIRA) and current settings on NFT - setup manually by TechOps at Som's request

SFAT-237 - Encryption

Updated connection string to use cluster rather than instance specific. Also updated Agreements to use read-only endpoint, as it does not require write access, and read endpoint should be more scalable.

NFT - increased number of instances to 3. This should create an instance in each AZ. I have tested deleting the current instance - and observed it is a faultless rollover of connections to another instance. In addition - if you delete the Writer instance, one of the reader instances is promoted to a new writer.