### PR TITLE
Set cluster instances to default for SBX4

### DIFF
--- a/terraform/environments/sbx4/main.tf
+++ b/terraform/environments/sbx4/main.tf
@@ -35,5 +35,4 @@ module "deploy" {
   deletion_protection             = false
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
-  guided_match_cluster_instances  = 2
 }


### PR DESCRIPTION
Doesn't need 2 read instances for SBX4 (aligns with TST)