### PR TITLE
SINF-406 - set publicy_accessible to false

### DIFF
--- a/terraform/modules/guided-match/main.tf
+++ b/terraform/modules/guided-match/main.tf
@@ -122,7 +122,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   instance_class       = var.db_instance_class
   engine               = "aurora-postgresql"
   apply_immediately    = true
-  publicly_accessible  = true
+  publicly_accessible  = false
   db_subnet_group_name = aws_db_subnet_group.guided_match.name
 }
 


### PR DESCRIPTION
Following observations from Zac - changed `publicly_accessible` from `true` to `false` (db was not actually available publicly, but better to have this flag set to false anyway).

Tested on SBX1. Updated DB and reset connections (by killing ECS tasks and letting new ones be generated) - and UI and Postman continued to function 