### PR TITLE
SINF-406 - removed explicit 11.8 postgres version

### DIFF
--- a/terraform/modules/guided-match/main.tf
+++ b/terraform/modules/guided-match/main.tf
@@ -92,7 +92,6 @@ resource "aws_rds_cluster" "default" {
   master_username                 = data.aws_ssm_parameter.master_username.value
   master_password                 = data.aws_ssm_parameter.master_password.value
   engine                          = "aurora-postgresql"
-  engine_version                  = "11.8"
   apply_immediately               = true
   vpc_security_group_ids          = ["${aws_security_group.allow_postgres_external.id}"]
   deletion_protection             = var.deletion_protection


### PR DESCRIPTION
Postgres had been auto updated to 11.9. Removing this means it will
align to the default version in future